### PR TITLE
list the valid math expressions

### DIFF
--- a/docs/tags/global.md
+++ b/docs/tags/global.md
@@ -141,6 +141,10 @@ Holds up processing. This does not schedule execution for later, it pauses execu
 
 Evaluates math. `precision_fix` enables a hack that fixes floating point precision errors, but may cause issues in very specific circumstances. Realistically nothing you do with actions should require disabling `precision_fix`.
 
+#### Supported Expressions
+
+```*, /, %, &, |, ^, +, -, (), sqrt(), log(), sin(), cos(), tan()```
+
 ## `{random length=1 return_array=false;haystack}`
 
 Gets a random item from a list. `length` is the number of items to return. When `length` is true, you can choose to return the random items in an array with `return_array`.

--- a/docs/tags/user.md
+++ b/docs/tags/user.md
@@ -18,7 +18,7 @@ Returns a boolean whether a user is a bot account.
 
 ## `{user.tag;user}`
 
-Returns the tag of a user with the username and discriminator, for example `DracoClaw#0065`.
+Returns the tag of a user with the username and discriminator, for example `Grainus#0432`.
 
 ## `{user.discriminator;user}`
 


### PR DESCRIPTION
simply adds the supported expressions to be used with `{math}`
