### PR TITLE
update {if} description

### DIFF
--- a/docs/tags/global.md
+++ b/docs/tags/global.md
@@ -253,7 +253,7 @@ Formats a number. [Formats using the context locale if possible](https://en.wiki
 
 ## `{if}`
 
-Compares different values and executes instructions based on the result. Syntax is `{if;condition;run_if_true;run_if_false}`. `condition` is either a boolean or a comparison with two elements and an operator such as `{if;10;>;5;10 is greater than 5;10 is not greater than 5;`. The available operators are `===`, `==`, `!=`, `>=`, `>`, `<=`, `<`, `!==`, and `matching`.
+Compares different values and executes instructions based on the result. Syntax is `{if;condition;run_if_true;run_if_false}`. `condition` is either a boolean or a comparison with two elements and an operator. The available operators are `==`, `===`, `!=`, `!==`, `>`, `>=`, `<`, `<=`, and `matches`.
 
 ```json
 // "==" is used for case-insensitive comparison


### PR DESCRIPTION
- remove the example from the text since there are already examples below
- switch around operator order for my mild OCD
- fix misspelt operator (matching -> matches)