### PR TITLE
Add list of color name defaults

### DIFF
--- a/docs/tags/responder.md
+++ b/docs/tags/responder.md
@@ -45,6 +45,7 @@ Embed Elements
 `url`
 
 Use the [Embed Builder](https://staging.atlas.bot/tools/embed-builder) to quickly build an embed.
+[Here](https://micro.sylo.digital/p/cKM30n) is a list of valid color name defaults.
 
 ## `{responder.embedField;name;value;inline}`
 

--- a/docs/tags/role.md
+++ b/docs/tags/role.md
@@ -56,6 +56,8 @@ Edit the role.
 {role.edit name="Very cool" colour=teal}
 ```
 
+[Here](https://micro.sylo.digital/p/cKM30n) is a list of valid color name defaults.
+
 ## `{role.create name color reason return_id;role}`
 
 Create a new role.
@@ -64,6 +66,8 @@ Create a new role.
 `color` is the colour of the role
 `reason` is the reason for creating the role
 `return_id` is whether to return the created roles ID.
+
+[Here](https://micro.sylo.digital/p/cKM30n) is a list of valid color name defaults.
 
 ## `{role.delete reason;role}`
 


### PR DESCRIPTION
Adds a link to a list of color name defaults, valid names that atlas reads as colors. 

listed under, {responder.embed}, {role.edit}, and {role.create}