### PR TITLE
Fixed channel.edit description

### DIFF
--- a/docs/tags/channel.md
+++ b/docs/tags/channel.md
@@ -71,6 +71,7 @@ Updates a channel.
 - `name`: The new name of the channel.
 - `topic`: The new topic of the channel.
 - `nsfw`: Whether the channel is NSFW or not.
+- `archived`: Whether this channel is archived/closed; channel must be a thread.
 - `locked`: Whether this channel is locked; channel must be a thread.
 - `ratelimit`: How often users can send messages in this channel, for example `1m`.
 - `parent`: The category to move the channel to.

--- a/docs/tags/channel.md
+++ b/docs/tags/channel.md
@@ -71,7 +71,7 @@ Updates a channel.
 - `name`: The new name of the channel.
 - `topic`: The new topic of the channel.
 - `nsfw`: Whether the channel is NSFW or not.
-- `archived`: Whether this channel is archived; channel must be a thread.
+- `locked`: Whether this channel is locked; channel must be a thread.
 - `ratelimit`: How often users can send messages in this channel, for example `1m`.
 - `parent`: The category to move the channel to.
 


### PR DESCRIPTION
`archived` does not seem to be a tag any more, but `locked` does, which seems like the correct one