### PR TITLE
Fixed mistypo in {fetch} tag example

### DIFF
--- a/docs/tags/global.md
+++ b/docs/tags/global.md
@@ -171,7 +171,7 @@ Performs a HTTP request to a URL.
 `application/xml`, `text/xml`, `application/rss+xml` and `application/atom+xml` will be parsed as XML.
 
 ```
-{=data;{fetch;https://atlas.bot/api/status}}\n{$data.body.ok}  // true
+{=data;{fetch;https://atlas.bot/api/status}}\n{$data.ok}  // true
 ```
 
 ## `{or boolean?;...}`


### PR DESCRIPTION
the `ok` key is in `{$data.ok}` tag, instead of `{$data.body.ok}`